### PR TITLE
No longer beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# hub-beta-feedback
+# hub-feedback
 
-Use this repository to file bugs against the [hub beta site](https://hub-beta.docker.com/).
+Use this repository to file bugs against the [hub site](https://hub.docker.com/).
 
 1. Look to see if someone already filled the bug, if not add a new one.
 2. Add a good title and description with the following information.


### PR DESCRIPTION
* Updates URL
* Drops betas from name

Suggestion: Maybe this repo should be renamed, as well.